### PR TITLE
修正註冊頁的隱私條款勾選沒有反應的問題

### DIFF
--- a/apps/web/src/components/account/account-register-form.tsx
+++ b/apps/web/src/components/account/account-register-form.tsx
@@ -31,6 +31,7 @@ function AccountRegisterForm() {
     handleSubmit,
     setValue,
     getValues,
+    watch,
     formState: { errors },
   } = useForm<AccountRegisterFormData>();
   const mutation = useMutation({
@@ -53,6 +54,7 @@ function AccountRegisterForm() {
   const onSubmit = handleSubmit((data) => {
     mutation.mutate(data);
   });
+  const confirmTermsAndPrivacy = watch("confirmTermsAndPrivacy");
 
   return (
     <form
@@ -119,10 +121,10 @@ function AccountRegisterForm() {
           onClick={() => {
             setValue(
               "confirmTermsAndPrivacy",
-              !getValues("confirmTermsAndPrivacy")
+              !confirmTermsAndPrivacy
             );
           }}
-          checked={getValues("confirmTermsAndPrivacy")}
+          checked={confirmTermsAndPrivacy}
         >
           註冊即表示您同意我們的{" "}
           <Link href="/terms" className="text-blue-500">


### PR DESCRIPTION
你好

我最近在看你在 COSCUP 的簡報資料，覺得你的專案很有趣

試著載下來本地跑的時候，發現註冊頁的隱私條款勾選沒有反應

我想應該是 `react-hook-form` 的 `getValues` 不會觸發 re-render 畫面的緣故，根據官方的文件，我試著改成了 `watch`，你看看這樣改 OK 不 OK~

參考：https://react-hook-form.com/docs/useform/getvalues